### PR TITLE
Feat/set identity path

### DIFF
--- a/selene_api/api.py
+++ b/selene_api/api.py
@@ -51,7 +51,7 @@ def timed_lru_cache(
 
 
 class BaseApi:
-    def __init__(self, url=None, version="v1"):
+    def __init__(self, url=None, version="v1", identity_file=None):
 
         if not url:
             config = Configuration()
@@ -59,15 +59,17 @@ class BaseApi:
             url = config_server.get("url")
             version = config_server.get("version") or version
 
+        self._identity_file = identity_file
         self.backend_url = url or "https://api.mycroft.ai"
         self.backend_version = version
         self.url = url
 
     @property
     def identity(self):
-        # TODO - allow manually specifying the location
-        # this is helpful if copying over the identity to a non-mycroft device
-        # eg, selene call out proxy in local backend
+        if self._identity_file:
+            # this is helpful if copying over the identity to a non-mycroft device
+            # eg, selene call out proxy in local backend
+            IdentityManager.set_identity_file(self._identity_file)
         return IdentityManager.get()
 
     @property

--- a/selene_api/api.py
+++ b/selene_api/api.py
@@ -133,8 +133,8 @@ class BaseApi:
 
 
 class DeviceApi(BaseApi):
-    def __init__(self, url=None, version="v1"):
-        super().__init__(url, version)
+    def __init__(self, url=None, version="v1", identity_file=None):
+        super().__init__(url, version, identity_file)
         self.url = f"{self.backend_url}/{self.backend_version}/device"
 
     def get(self, url=None, *args, **kwargs):
@@ -298,8 +298,8 @@ class DeviceApi(BaseApi):
 
 
 class STTApi(BaseApi):
-    def __init__(self, url=None, version="v1"):
-        super().__init__(url, version)
+    def __init__(self, url=None, version="v1", identity_file=None):
+        super().__init__(url, version, identity_file)
         self.url = f"{self.backend_url}/{self.backend_version}/stt"
 
     @property
@@ -328,8 +328,8 @@ class STTApi(BaseApi):
 class GeolocationApi(BaseApi):
     """Web API wrapper for performing geolocation lookups."""
 
-    def __init__(self, url=None, version="v1"):
-        super().__init__(url, version)
+    def __init__(self, url=None, version="v1", identity_file=None):
+        super().__init__(url, version, identity_file)
         self.url = f"{self.backend_url}/{self.backend_version}/geolocation"
 
     def get_geolocation(self, location):
@@ -347,8 +347,8 @@ class GeolocationApi(BaseApi):
 
 class WolframAlphaApi(BaseApi):
 
-    def __init__(self, url=None, version="v1"):
-        super().__init__(url, version)
+    def __init__(self, url=None, version="v1", identity_file=None):
+        super().__init__(url, version, identity_file)
         self.url = f"{self.backend_url}/{self.backend_version}/wolframAlpha"
 
     # cached to save api calls, wolfram answer wont change often
@@ -396,8 +396,8 @@ class WolframAlphaApi(BaseApi):
 class OpenWeatherMapApi(BaseApi):
     """Use Open Weather Map's One Call API to retrieve weather information"""
 
-    def __init__(self, url=None, version="v1"):
-        super().__init__(url, version)
+    def __init__(self, url=None, version="v1", identity_file=None):
+        super().__init__(url, version, identity_file)
         self.url = f"{self.backend_url}/{self.backend_version}/owm"
 
     @staticmethod

--- a/selene_api/identity.py
+++ b/selene_api/identity.py
@@ -62,6 +62,11 @@ class IdentityManager:
     OLD_IDENTITY_FILE = expanduser(f"~/.{get_xdg_base()}/identity/identity2.json")
     __identity = None
 
+    @classmethod
+    def set_identity_file(cls, identity_path):
+        cls.IDENTITY_FILE = identity_path
+        cls.load()
+
     @staticmethod
     def _load():
         if isfile(IdentityManager.OLD_IDENTITY_FILE) and \
@@ -69,7 +74,7 @@ class IdentityManager:
             os.makedirs(dirname(IdentityManager.IDENTITY_FILE), exist_ok=True)
             shutil.move(IdentityManager.OLD_IDENTITY_FILE, IdentityManager.IDENTITY_FILE)
         if isfile(IdentityManager.IDENTITY_FILE):
-            LOG.debug('Loading identity')
+            LOG.debug(f'Loading identity: {IdentityManager.IDENTITY_FILE}')
             try:
                 with open(IdentityManager.IDENTITY_FILE) as f:
                     IdentityManager.__identity = DeviceIdentity(**json.load(f))


### PR DESCRIPTION
allow defining an alternative path for identity2.json

this is helpful if copying over the identity to a non-mycroft device

eg, selene call out proxy in local backend as discussed in https://github.com/OpenVoiceOS/OVOS-local-backend/issues/20