### PR TITLE
add neon backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,23 @@ Python client library for interaction with several supported backends under a si
 - Personal backend - [self hosted](https://github.com/OpenVoiceOS/OVOS-local-backend)
 - Selene - https://api.mycroft.ai
 - OpenVoiceOS API Service - https://api.openvoiceos.com
+- Neon MQ Service - https://api.neon.ai
 - Offline - support for setting your own api keys and query services directly
 
 ## Backend Overview
 
-| API       | Offline | Personal | Selene | OVOS    | 
-|-----------|---------|----------|--------|---------|
-| Admin     | yes [1] | yes      | no     | no      | 
-| Device    | yes [2] | yes      | yes    | yes [4] | 
-| Metrics   | yes [2] | yes      | yes    | yes [4] | 
-| Dataset   | yes [2] | yes      | yes    | yes [4] | 
-| OAuth     | yes [2] | yes      | yes    | yes [4] |
-| Wolfram   | yes [3] | yes      | yes    | yes     | 
-| Geolocate | yes     | yes      | yes    | yes     |
-| STT       | yes [3] | yes      | yes    | yes     | 
-| Weather   | yes [3] | yes      | yes    | yes     | 
-| Email     | yes [3] | yes      | yes    | yes     |
+| API       | Offline | Personal | Selene | OVOS    | Neon     |
+|-----------|---------|----------|--------|---------|----------|
+| Admin     | yes [1] | yes      | no     | no      | no       |
+| Device    | yes [2] | yes      | yes    | yes [4] | yes [4]  | 
+| Metrics   | yes [2] | yes      | yes    | yes [4] | yes      | 
+| Dataset   | yes [2] | yes      | yes    | yes [4] | yes [4]  |
+| OAuth     | yes [2] | yes      | yes    | yes [4] | yes [4]  |
+| Wolfram   | yes [3] | yes      | yes    | yes     | yes      |
+| Geolocate | yes     | yes      | yes    | yes     | yes      |
+| STT       | yes [3] | yes      | yes    | yes     | yes      |
+| Weather   | yes [3] | yes      | yes    | yes     | yes      |
+| Email     | yes [3] | yes      | yes    | yes     | yes      |
 
     [1] will update user level mycroft.conf
     [2] shared json database with personal backend for UI compat

--- a/ovos_backend_client/api.py
+++ b/ovos_backend_client/api.py
@@ -1,7 +1,7 @@
 from ovos_utils import timed_lru_cache
 from ovos_utils.log import LOG
 
-from ovos_backend_client.backends import OfflineBackend, OVOSAPIBackend, \
+from ovos_backend_client.backends import OfflineBackend, OVOSAPIBackend, NeonMQBackend, \
     SeleneBackend, PersonalBackend, BackendType, get_backend_config, API_REGISTRY
 
 
@@ -15,6 +15,8 @@ class BaseApi:
             self.backend = SeleneBackend(url, version, identity_file)
         elif backend_type == BackendType.PERSONAL:
             self.backend = PersonalBackend(url, version, identity_file)
+        elif backend_type == BackendType.NEON_MQ:
+            self.backend = NeonMQBackend(url, version, identity_file)
         elif backend_type == BackendType.OVOS_API:
             self.backend = OVOSAPIBackend(url, version, identity_file)
         else:  # if backend_type == BackendType.OFFLINE:
@@ -336,6 +338,8 @@ class GeolocationApi(BaseApi):
             self.url = f"{self.backend_url}/geolocate"
         elif self.backend_type == BackendType.OFFLINE:
             self.url = "https://nominatim.openstreetmap.org"
+        elif self.backend_type == BackendType.NEON_MQ:
+            self.url = self.backend_url
         else:
             self.url = f"{self.backend_url}/{self.backend_version}/geolocation"
 
@@ -366,6 +370,8 @@ class WolframAlphaApi(BaseApi):
             self.url = f"{self.backend_url}/wolframalpha"
         elif self.backend_type == BackendType.OFFLINE:
             self.url = "https://api.wolframalpha.com"
+        elif self.backend_type == BackendType.NEON_MQ:
+            self.url = self.backend_url
         else:
             self.url = f"{self.backend_url}/{self.backend_version}/wolframAlpha"
 
@@ -404,6 +410,8 @@ class OpenWeatherMapApi(BaseApi):
             self.url = f"{self.backend_url}/weather"
         elif self.backend_type == BackendType.OFFLINE:
             self.url = "https://api.openweathermap.org/data/2.5"
+        elif self.backend_type == BackendType.NEON_MQ:
+            self.url = self.backend_url
         else:
             self.url = f"{self.backend_url}/{self.backend_version}/owm"
 

--- a/ovos_backend_client/backends/__init__.py
+++ b/ovos_backend_client/backends/__init__.py
@@ -1,6 +1,7 @@
 from ovos_config.config import Configuration
 
 from ovos_backend_client.backends.base import BackendType
+from ovos_backend_client.backends.neon import NEON_API_URL, NeonMQBackend
 from ovos_backend_client.backends.offline import OfflineBackend
 from ovos_backend_client.backends.ovos import OVOS_API_URL, OVOSAPIBackend
 from ovos_backend_client.backends.personal import PersonalBackend
@@ -54,6 +55,18 @@ API_REGISTRY = {
         "owm": True,
         "email": True,
         "oauth": True  # fake support -> cast to offline backend type
+    },
+    BackendType.NEON_MQ: {  # neon_api_proxy extra requirement
+        "admin": True,  # fake support -> cast to offline backend type
+        "device": True,  # fake support -> cast to offline backend type
+        "dataset": True,  # fake support -> cast to offline backend type
+        "metrics": False,  # TODO - True, implement
+        "wolfram": True,
+        "geolocate": False,  # TODO - True (?), implement
+        "stt": False,  # TODO - True (?), implement
+        "owm": True,  # TODO - not all endpoints available upstream
+        "email": True,
+        "oauth": True  # fake support -> cast to offline backend type
     }
 }
 
@@ -73,6 +86,8 @@ def get_backend_type(conf=None):
         return BackendType.OVOS_API
     elif "mycroft.ai" in url:
         return BackendType.SELENE
+    elif "neon.ai" in url:
+        return BackendType.NEON_MQ
     return BackendType.PERSONAL
 
 
@@ -93,6 +108,8 @@ def get_backend_config(url=None, version="v1", identity_file=None, backend_type=
             url = OVOS_API_URL
         elif backend_type == BackendType.PERSONAL:
             url = "http://0.0.0.0:6712"
+        elif backend_type == BackendType.NEON_MQ:
+            url = NEON_API_URL
         else:
             url = "http://127.0.0.1"
 

--- a/ovos_backend_client/backends/base.py
+++ b/ovos_backend_client/backends/base.py
@@ -17,6 +17,7 @@ class BackendType(str, Enum):
     PERSONAL = "personal"
     SELENE = "selene"
     OVOS_API = "ovos_api"
+    NEON_MQ = "neon_mq"
 
 
 class AbstractBackend:

--- a/ovos_backend_client/backends/neon.py
+++ b/ovos_backend_client/backends/neon.py
@@ -1,0 +1,202 @@
+from ovos_backend_client.backends.offline import AbstractPartialBackend, BackendType
+
+try:
+    from neon_utils.mq_utils import send_mq_request as send_neon_mq
+except ImportError:
+    send_neon_mq = None
+
+NEON_API_URL = "https://api.neon.ai"
+
+
+class NeonMQBackend(AbstractPartialBackend):
+    def __init__(self, url=NEON_API_URL, version="v1", identity_file=None, credentials=None):
+        if send_neon_mq is None:
+            raise ImportError("neon_utils not installed!")
+        super().__init__(url, version, identity_file, BackendType.NEON_MQ, credentials)
+
+    @staticmethod
+    def _request_mq_api(neon_api: str,
+                        query_params: dict,
+                        timeout: int = 30) -> dict:
+        """
+        Handle a request for information from the Neon API Proxy Server
+        @param query_params: Data parameters to pass to remote API
+        @param timeout: Request timeout in seconds
+        @return: dict response from API with: `status_code`, `content`, and `encoding`
+        """
+
+        if not query_params:
+            raise ValueError("Got empty query params")
+        if not isinstance(query_params, dict):
+            raise TypeError(f"Expected dict, got: {query_params}")
+        query_params["service"] = neon_api
+        response = send_neon_mq("/neon_api", query_params, "neon_api_input", "neon_api_output", timeout)
+        return response or {"status_code": 401,
+                            "content": f"Neon API failed to give a response within {timeout} seconds",
+                            "encoding": None}
+
+    # OWM Api
+    def owm_get_weather(self, lat_lon=None, lang="en-us", units="metric"):
+        """Issue an API call and map the return value into a weather report
+
+        Args:
+            units (str): metric or imperial measurement units
+            lat_lon (tuple): the geologic (latitude, longitude) of the weather location
+        """
+        # default to configured location
+        lat, lon = lat_lon or self._get_lat_lon()
+        return self._request_mq_api(
+            "open_weather_map",
+            {
+                "units": units,
+                "lat": lat,
+                "lng": lon,
+                "lang": lang,
+                "api": "onecall"
+            })
+
+    def owm_get_current(self, lat_lon=None, lang="en-us", units="metric"):
+        """Issue an API call and map the return value into a weather report
+
+        Args:
+            units (str): metric or imperial measurement units
+            lat_lon (tuple): the geologic (latitude, longitude) of the weather location
+        """
+        # default to configured location
+        lat, lon = lat_lon or self._get_lat_lon()
+        return self._request_mq_api(
+            "open_weather_map",
+            {
+                "units": units,
+                "lat": lat,
+                "lng": lon,
+                "lang": lang,
+                "api": "weather"
+            })
+
+    def owm_get_hourly(self, lat_lon=None, lang="en-us", units="metric"):
+        """Issue an API call and map the return value into a weather report
+
+        Args:
+            units (str): metric or imperial measurement units
+            lat_lon (tuple): the geologic (latitude, longitude) of the weather location
+        """
+        raise NotImplementedError()
+
+    def owm_get_daily(self, lat_lon=None, lang="en-us", units="metric"):
+        """Issue an API call and map the return value into a weather report
+
+        Args:
+            units (str): metric or imperial measurement units
+            lat_lon (tuple): the geologic (latitude, longitude) of the weather location
+        """
+        raise NotImplementedError()
+
+    # Wolfram Alpha API
+    def wolfram_spoken(self, query, units="metric", lat_lon=None, optional_params=None):
+        optional_params = optional_params or {}
+        if not lat_lon:
+            lat_lon = self._get_lat_lon(**optional_params)
+        lat, lon = lat_lon
+        return self._request_mq_api(
+            "wolfram_alpha",
+            {
+                "units": units,
+                "lat": lat,
+                "lon": lon,
+                "query": query,
+                "api": "spoken"
+            })
+
+    def wolfram_simple(self, query, units="metric", lat_lon=None, optional_params=None):
+        optional_params = optional_params or {}
+        if not lat_lon:
+            lat_lon = self._get_lat_lon(**optional_params)
+        lat, lon = lat_lon
+        return self._request_mq_api(
+            "wolfram_alpha",
+            {
+                "units": units,
+                "lat": lat,
+                "lon": lon,
+                "query": query,
+                "api": "simple"
+            })
+
+    def wolfram_full_results(self, query, units="metric", lat_lon=None, optional_params=None):
+        """Wrapper for the WolframAlpha Full Results v2 API.
+        https://products.wolframalpha.com/api/documentation/
+        Pods of interest
+        - Input interpretation - Wolfram's determination of what is being asked about.
+        - Name - primary name of
+        """
+        optional_params = optional_params or {}
+        if not lat_lon:
+            lat_lon = self._get_lat_lon(**optional_params)
+        lat, lon = lat_lon
+        return self._request_mq_api(
+            "wolfram_alpha",
+            {
+                "units": units,
+                "lat": lat,
+                "lon": lon,
+                "query": query,
+                "api": "full"
+            })
+
+    # Geolocation Api
+    def geolocation_get(self, location):
+        """Call the geolocation endpoint.
+
+        Args:
+            location (str): the location to lookup (e.g. Kansas City Missouri)
+
+        Returns:
+            str: JSON structure with lookup results
+        """
+        raise NotImplementedError()  # TODO
+
+    # Metrics API
+    def metrics_upload(self, name, data):
+        """ upload metrics"""
+        raise NotImplementedError()  # TODO
+
+    # Email API
+    def email_send(self, title, body, sender):
+        mail_config = self.credentials["email"]
+        smtp_username = mail_config.get("smtp", {}).get("username")
+        recipient = mail_config.get("recipient") or smtp_username
+
+        request_data = {"recipient": recipient,
+                        "subject": title,
+                        "body": body,
+                        "attachments": {}}
+        # TODO - use self._request_mq_api()
+        data = send_neon_mq("/neon_emails", request_data,
+                            "neon_emails_input")
+        return data.get("success")
+
+    # STT Api
+    def stt_get(self, audio, language="en-us", limit=1):
+        """ Web API wrapper for performing Speech to Text (STT)
+
+        Args:
+            audio (bytes): The recorded audio, as in a FLAC file
+            language (str): A BCP-47 language code, e.g. "en-US"
+            limit (int): Maximum minutes to transcribe(?)
+
+       """
+        # if flac not supported
+        #
+        #     @staticmethod
+        #     def _get_wav_data(audio):
+        #         with NamedTemporaryFile() as fp:
+        #             fp.write(audio)
+        #             with AudioFile(fp.name) as source:
+        #                 audio = Recognizer().record(source)
+        #         return audio.get_wav_data()
+        #
+        #     content_type = "audio/wav"
+        #     audio = _get_wav_data(audio)
+        raise NotImplementedError()  # TODO
+

--- a/requirements/neon.txt
+++ b/requirements/neon.txt
@@ -1,0 +1,1 @@
+neon_utils

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
     author='jarbasai',
     install_requires=required("requirements/requirements.txt"),
     extras_require={
+        'neon': required('requirements/neon.txt'),
         'offline': required('requirements/offline.txt')
     },
     author_email='jarbasai@mailfence.com',


### PR DESCRIPTION
follow up to #10 

# NeonMQ Backend

Python client library for interaction with several supported backends under a single unified interface

- Personal backend - [self hosted](https://github.com/OpenVoiceOS/OVOS-local-backend)
- Selene - https://api.mycroft.ai
- OpenVoiceOS API Service - https://api.openvoiceos.com
- Neon MQ Service - https://api.neon.ai
- Offline - support for setting your own api keys and query services directly

## Backend Overview

| API       | Offline | Personal | Selene | OVOS     | Neon     |
|-----------|---------|----------|--------|----------|----------|
| Admin     | yes [1] | yes      | no     | no       | no       |
| Device    | yes [2] | yes      | yes    | yes [4]  | yes [4]  | 
| Metrics   | yes [2] | yes      | yes    | yes [4]  | yes      | 
| Dataset   | yes [2] | yes      | yes    | yes [4]  | yes [4]  |
| OAuth     | yes [2] | yes      | yes    | yes [4]  | yes [4]  |
| Wolfram   | yes [3] | yes      | yes    | yes      | yes      |
| Geolocate | yes     | yes      | yes    | yes      | yes      |
| STT       | yes [3] | yes      | yes    | yes      | yes      |u
| Weather   | yes [3] | yes      | yes    | yes      | yes      |
| Email     | yes [3] | yes      | yes    | yes      | yes      |

    [1] will update user level mycroft.conf
    [2] shared json database with personal backend for UI compat
    [3] needs additional configuration (eg. credentials)
    [4] uses offline_backend functionality

