### PR TITLE
fix/pairing_code_callback

### DIFF
--- a/ovos_backend_client/pairing.py
+++ b/ovos_backend_client/pairing.py
@@ -169,6 +169,7 @@ class PairingManager:
         try:
             # Obtain a pairing code from the backend
             self.data = self.api.get_code(self.uuid)
+            self.handle_pairing_code()
 
             # Keep track of when the code was obtained.  The codes expire
             # after 20 hours.


### PR DESCRIPTION
was only called by the activate time if activation failed, should also be called as soon as we receive the code the first time