### PR TITLE
Personal-backend: Workaround deadlock

### DIFF
--- a/ovos_backend_client/backends/personal.py
+++ b/ovos_backend_client/backends/personal.py
@@ -19,6 +19,7 @@ class PersonalBackend(AbstractPartialBackend):
 
     def refresh_token(self):
         try:
+            self.identity.get() # Ensure loading so identity property doesn't cause deadlock
             identity_lock.acquire(blocking=False)
             # NOTE: requests needs to be used instead of self.get due to self.get calling this
             data = requests.get(f"{self.backend_url}/{self.backend_version}/auth/token", headers=self.headers).json()


### PR DESCRIPTION
Using the identity property when fetching headers (headers -> uuid -> identity) caused a deadlock since a load occured.

This ensures that the load is performed before the lock is taken to ensure the deadlock does not occur.

This is a quick-fix and someone with more insight in the architecture (or me if I get a weekend to think it through) may want to make a proper fix.

Resolves #36 