### PR TITLE
fix remote download loop

### DIFF
--- a/ovos_backend_client/backends/__init__.py
+++ b/ovos_backend_client/backends/__init__.py
@@ -43,7 +43,7 @@ def get_backend_type(conf=None):
     if conf.get("disabled"):
         return BackendType.OFFLINE
     if "backend_type" in conf:
-        return conf["backend_type"]
+        return BackendType[conf["backend_type"].upper()]
     url = conf.get("url")
     if not url:
         return BackendType.OFFLINE


### PR DESCRIPTION
When downloading remote configuration in `RemoteConfigManager`, checks for protected keys
and deletes those. 

_(this is what is done by `Configuration.load_all_configs()` leading to a loop when comparing both dicts)_