### PR TITLE
refactor!:deprecate_refresh_endpoint

### DIFF
--- a/ovos_backend_client/api.py
+++ b/ovos_backend_client/api.py
@@ -1,15 +1,12 @@
-from ovos_utils import timed_lru_cache
-from ovos_utils.log import LOG
-
 import json
-import os
 from os import makedirs
-from os.path import isfile
-from ovos_config.config import Configuration, get_xdg_config_save_path
+
 from ovos_backend_client.backends import OfflineBackend, \
     PersonalBackend, BackendType, get_backend_config, API_REGISTRY
-from ovos_backend_client.database import SkillSettingsModel
 from ovos_backend_client.settings import get_local_settings
+from ovos_config.config import Configuration, get_xdg_config_save_path
+from ovos_utils import timed_lru_cache
+from ovos_utils.log import LOG
 
 
 class BaseApi:
@@ -547,7 +544,7 @@ class SkillSettingsApi(BaseApi):
         for s in settings:  # list of SkillSettingsModel or dicts
             settings_path = f"{get_xdg_config_save_path()}/skills/{s.skill_id}"
             makedirs(settings_path, exist_ok=True)
-            with open( f"{settings_path}/settingsmeta.json", "w") as f:
+            with open(f"{settings_path}/settingsmeta.json", "w") as f:
                 json.dump(s.meta, f, indent=4, ensure_ascii=False)
             with open(f"{settings_path}/settings.json", "w") as f:
                 json.dump(s.skill_settings, f, indent=4, ensure_ascii=False)
@@ -721,19 +718,19 @@ class DatabaseApi(BaseApi):
         return self.backend.db_get_oauth_app(token_id)
 
     def update_oauth_app(self, token_id, client_id=None, client_secret=None,
-                         auth_endpoint=None, token_endpoint=None, refresh_endpoint=None,
+                         auth_endpoint=None, token_endpoint=None,
                          callback_endpoint=None, scope=None, shell_integration=None):
         return self.backend.db_update_oauth_app(token_id, client_id, client_secret, auth_endpoint, token_endpoint,
-                                                refresh_endpoint, callback_endpoint, scope, shell_integration)
+                                                callback_endpoint, scope, shell_integration)
 
     def delete_oauth_app(self, token_id):
         return self.backend.db_delete_oauth_app(token_id)
 
     def add_oauth_app(self, token_id, client_id, client_secret,
-                      auth_endpoint, token_endpoint, refresh_endpoint,
+                      auth_endpoint, token_endpoint,
                       callback_endpoint, scope, shell_integration=True):
         return self.backend.db_post_oauth_app(token_id, client_id, client_secret, auth_endpoint, token_endpoint,
-                                              refresh_endpoint, callback_endpoint, scope, shell_integration)
+                                              callback_endpoint, scope, shell_integration)
 
     def list_oauth_tokens(self):
         return self.backend.db_list_oauth_tokens()

--- a/ovos_backend_client/backends/base.py
+++ b/ovos_backend_client/backends/base.py
@@ -4,10 +4,9 @@ from enum import Enum
 from io import BytesIO, StringIO
 
 import requests
-from ovos_config.config import Configuration
-
 from ovos_backend_client.database import SkillSettingsModel
 from ovos_backend_client.identity import IdentityManager
+from ovos_config.config import Configuration
 
 try:
     from timezonefinder import TimezoneFinder
@@ -586,7 +585,7 @@ class AbstractBackend:
 
     @abc.abstractmethod
     def db_update_oauth_app(self, token_id, client_id=None, client_secret=None,
-                            auth_endpoint=None, token_endpoint=None, refresh_endpoint=None,
+                            auth_endpoint=None, token_endpoint=None,
                             callback_endpoint=None, scope=None, shell_integration=None):
         raise NotImplementedError()
 
@@ -596,7 +595,7 @@ class AbstractBackend:
 
     @abc.abstractmethod
     def db_post_oauth_app(self, token_id, client_id, client_secret,
-                          auth_endpoint, token_endpoint, refresh_endpoint,
+                          auth_endpoint, token_endpoint,
                           callback_endpoint, scope, shell_integration=True):
         raise NotImplementedError()
 

--- a/ovos_backend_client/backends/offline.py
+++ b/ovos_backend_client/backends/offline.py
@@ -8,18 +8,17 @@ from uuid import uuid4
 
 import requests
 from oauthlib.oauth2 import WebApplicationClient
+from ovos_backend_client.backends.base import AbstractBackend, BackendType
+from ovos_backend_client.database import JsonMetricDatabase, JsonWakeWordDatabase, \
+    SkillSettingsModel, OAuthTokenDatabase, OAuthApplicationDatabase, DeviceModel, JsonUtteranceDatabase
+from ovos_backend_client.identity import IdentityManager
+from ovos_backend_client.settings import get_local_settings
 from ovos_config.config import Configuration, update_mycroft_config, get_xdg_config_save_path
 from ovos_config.locations import USER_CONFIG, get_xdg_data_save_path, xdg_data_home
 from ovos_utils import timed_lru_cache
 from ovos_utils.log import LOG
 from ovos_utils.network_utils import get_external_ip
 from ovos_utils.smtp_utils import send_smtp
-
-from ovos_backend_client.backends.base import AbstractBackend, BackendType
-from ovos_backend_client.database import JsonMetricDatabase, JsonWakeWordDatabase, \
-    SkillSettingsModel, OAuthTokenDatabase, OAuthApplicationDatabase, DeviceModel, JsonUtteranceDatabase
-from ovos_backend_client.identity import IdentityManager
-from ovos_backend_client.settings import get_local_settings
 
 try:
     from ovos_plugin_manager.tts import get_voices, get_voice_id
@@ -820,11 +819,11 @@ class OfflineBackend(AbstractBackend):
         return OAuthApplicationDatabase().get_application(token_id)
 
     def db_update_oauth_app(self, token_id, client_id=None, client_secret=None,
-                            auth_endpoint=None, token_endpoint=None, refresh_endpoint=None,
+                            auth_endpoint=None, token_endpoint=None,
                             callback_endpoint=None, scope=None, shell_integration=None):
         with OAuthApplicationDatabase() as db:
             return db.add_token(token_id, client_id, client_secret,
-                                auth_endpoint, token_endpoint, refresh_endpoint,
+                                auth_endpoint, token_endpoint,
                                 callback_endpoint, scope, shell_integration)
 
     def db_delete_oauth_app(self, token_id):
@@ -832,12 +831,11 @@ class OfflineBackend(AbstractBackend):
             return db.delete_application(token_id)
 
     def db_post_oauth_app(self, token_id, client_id, client_secret,
-                          auth_endpoint, token_endpoint, refresh_endpoint,
+                          auth_endpoint, token_endpoint,
                           callback_endpoint, scope, shell_integration=True):
         with OAuthApplicationDatabase() as db:
             return db.add_application(token_id, client_id, client_secret,
-                                      auth_endpoint, token_endpoint,
-                                      refresh_endpoint, callback_endpoint,
+                                      auth_endpoint, token_endpoint, callback_endpoint,
                                       scope, shell_integration)
 
     def db_list_oauth_tokens(self):

--- a/ovos_backend_client/backends/personal.py
+++ b/ovos_backend_client/backends/personal.py
@@ -5,13 +5,12 @@ import time
 from io import BytesIO, StringIO
 
 import requests
-from ovos_config.config import Configuration
-from ovos_utils.log import LOG
-from requests.exceptions import HTTPError
-
 from ovos_backend_client.backends.offline import AbstractPartialBackend, BackendType
 from ovos_backend_client.database import SkillSettingsModel
 from ovos_backend_client.identity import IdentityManager, identity_lock
+from ovos_config.config import Configuration
+from ovos_utils.log import LOG
+from requests.exceptions import HTTPError
 
 
 class PersonalBackend(AbstractPartialBackend):
@@ -414,8 +413,8 @@ class PersonalBackend(AbstractPartialBackend):
 
     def admin_update_backend_config(self, config):
         return self.post(f"{self.backend_url}/{self.backend_version}/admin/config",
-                        json={"config": config},
-                        headers={"Authorization": f"Bearer {self.credentials['admin']}"}).json()
+                         json={"config": config},
+                         headers={"Authorization": f"Bearer {self.credentials['admin']}"}).json()
 
     def admin_set_device_location(self, uuid, loc):
         """
@@ -619,12 +618,11 @@ class PersonalBackend(AbstractPartialBackend):
                         headers={"Authorization": f"Bearer {self.credentials['admin']}"}).json()
 
     def db_update_oauth_app(self, token_id, client_id=None, client_secret=None,
-                            auth_endpoint=None, token_endpoint=None, refresh_endpoint=None,
+                            auth_endpoint=None, token_endpoint=None,
                             callback_endpoint=None, scope=None, shell_integration=None):
         payload = {"client_id": client_id, "client_secret": client_secret,
                    "auth_endpoint": auth_endpoint,
                    "token_endpoint": token_endpoint,
-                   "refresh_endpoint": refresh_endpoint,
                    "callback_endpoint": callback_endpoint,
                    "scope": scope, "shell_integration": True}
         return self.put(url=f"{self.backend_url}/{self.backend_version}/admin/oauth_apps/{token_id}",
@@ -636,14 +634,13 @@ class PersonalBackend(AbstractPartialBackend):
                            headers={"Authorization": f"Bearer {self.credentials['admin']}"}).json()
 
     def db_post_oauth_app(self, token_id, client_id, client_secret,
-                          auth_endpoint, token_endpoint, refresh_endpoint,
+                          auth_endpoint, token_endpoint,
                           callback_endpoint, scope, shell_integration=True):
         payload = {"token_id": token_id,
                    "client_id": client_id,
                    "client_secret": client_secret,
                    "auth_endpoint": auth_endpoint,
                    "token_endpoint": token_endpoint,
-                   "refresh_endpoint": refresh_endpoint,
                    "callback_endpoint": callback_endpoint,
                    "scope": scope, "shell_integration": True}
         return self.post(url=f"{self.backend_url}/{self.backend_version}/admin/oauth_apps",


### PR DESCRIPTION
continuation of https://github.com/OpenVoiceOS/ovos-backend-client/pull/61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified OAuth application management by removing the `refresh_endpoint` parameter from several API methods, enhancing usability.
- **Bug Fixes**
	- Improved code clarity and maintainability through reorganization of import statements and formatting adjustments.
- **Refactor**
	- Streamlined method signatures across multiple backend classes to focus on essential parameters for OAuth applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->